### PR TITLE
종합적인 에러부분 수정 및 뷰모델도입중 - feature-13-13.14

### DIFF
--- a/Moment/Moment.xcodeproj/project.pbxproj
+++ b/Moment/Moment.xcodeproj/project.pbxproj
@@ -8,7 +8,6 @@
 
 /* Begin PBXBuildFile section */
 		095131622B31216200F6BC4C /* FormattedTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 095131612B31216200F6BC4C /* FormattedTime.swift */; };
-		0951317E2B32CDA300F6BC4C /* APIKEY.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0951317D2B32CDA300F6BC4C /* APIKEY.plist */; };
 		09731F772B26C5780045F6B4 /* DataTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09731F762B26C5780045F6B4 /* DataTest.swift */; };
 		09731F7D2B26C5980045F6B4 /* OnboardingMainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09731F7C2B26C5980045F6B4 /* OnboardingMainView.swift */; };
 		09731F842B26C8AB0045F6B4 /* ImageHorizontalScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09731F832B26C8AB0045F6B4 /* ImageHorizontalScrollView.swift */; };
@@ -48,6 +47,8 @@
 		7B39C0C72B2ADC7400460278 /* UIImage +.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B39C0C62B2ADC7400460278 /* UIImage +.swift */; };
 		7B39C0C92B2ADCE000460278 /* SwiftDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B39C0C82B2ADCE000460278 /* SwiftDataModel.swift */; };
 		7B39C0CB2B2AFCC700460278 /* APIDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B39C0CA2B2AFCC700460278 /* APIDataModel.swift */; };
+		7B649C252B38767F00586040 /* APIKEY.plist in Resources */ = {isa = PBXBuildFile; fileRef = 7B649C242B38767F00586040 /* APIKEY.plist */; };
+		7B649C272B38789100586040 /* MainViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B649C262B38789100586040 /* MainViewModel.swift */; };
 		7BE6E0B72B2820FC00D8842D /* RecordLocalData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BE6E0B62B2820FC00D8842D /* RecordLocalData.swift */; };
 		AC4CA6752B26CFCA0066E9EB /* BookApiSearchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC4CA6742B26CFCA0066E9EB /* BookApiSearchBar.swift */; };
 		AC4CA6772B26CFFA0066E9EB /* SegmentBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC4CA6762B26CFFA0066E9EB /* SegmentBar.swift */; };
@@ -73,8 +74,6 @@
 
 /* Begin PBXFileReference section */
 		095131612B31216200F6BC4C /* FormattedTime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormattedTime.swift; sourceTree = "<group>"; };
-		0951317D2B32CDA300F6BC4C /* APIKEY.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = APIKEY.plist; path = "../../ㅇㄴㅁㅇ/Moment/APIKEY.plist"; sourceTree = "<group>"; };
-		0951317F2B32CDA500F6BC4C /* APIKEY.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = APIKEY.plist; sourceTree = "<group>"; };
 		09731F762B26C5780045F6B4 /* DataTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataTest.swift; sourceTree = "<group>"; };
 		09731F7C2B26C5980045F6B4 /* OnboardingMainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingMainView.swift; sourceTree = "<group>"; };
 		09731F832B26C8AB0045F6B4 /* ImageHorizontalScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageHorizontalScrollView.swift; sourceTree = "<group>"; };
@@ -116,6 +115,8 @@
 		7B39C0C62B2ADC7400460278 /* UIImage +.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage +.swift"; sourceTree = "<group>"; };
 		7B39C0C82B2ADCE000460278 /* SwiftDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftDataModel.swift; sourceTree = "<group>"; };
 		7B39C0CA2B2AFCC700460278 /* APIDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIDataModel.swift; sourceTree = "<group>"; };
+		7B649C242B38767F00586040 /* APIKEY.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = APIKEY.plist; sourceTree = "<group>"; };
+		7B649C262B38789100586040 /* MainViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewModel.swift; sourceTree = "<group>"; };
 		7BE6E0B62B2820FC00D8842D /* RecordLocalData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordLocalData.swift; sourceTree = "<group>"; };
 		AC4CA6742B26CFCA0066E9EB /* BookApiSearchBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookApiSearchBar.swift; sourceTree = "<group>"; };
 		AC4CA6762B26CFFA0066E9EB /* SegmentBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SegmentBar.swift; sourceTree = "<group>"; };
@@ -163,7 +164,6 @@
 		09AB7CD72B26A1350073EAD5 = {
 			isa = PBXGroup;
 			children = (
-				0951317D2B32CDA300F6BC4C /* APIKEY.plist */,
 				09AB7CE22B26A1350073EAD5 /* Moment */,
 				09AB7CE12B26A1350073EAD5 /* Products */,
 			);
@@ -190,7 +190,7 @@
 				09AB7CE72B26A1370073EAD5 /* Assets.xcassets */,
 				09AB7CF12B26A1660073EAD5 /* Colors.xcassets */,
 				09AB7D1A2B26A82B0073EAD5 /* Info.plist */,
-				0951317F2B32CDA500F6BC4C /* APIKEY.plist */,
+				7B649C242B38767F00586040 /* APIKEY.plist */,
 				09AB7CE92B26A1370073EAD5 /* Preview Content */,
 			);
 			path = Moment;
@@ -264,6 +264,7 @@
 			isa = PBXGroup;
 			children = (
 				09D7750E2B296F2D00D45EE6 /* MainView.swift */,
+				7B649C262B38789100586040 /* MainViewModel.swift */,
 				AC72AD172B27ECDD0082A9DB /* MainShelf */,
 				7B1B0B662B26CFA100CD19AD /* MainMap */,
 			);
@@ -458,7 +459,7 @@
 				09AB7CF22B26A1660073EAD5 /* Colors.xcassets in Resources */,
 				09AB7D162B26A73C0073EAD5 /* Pretendard-Bold.otf in Resources */,
 				09AB7D192B26A73C0073EAD5 /* Pretendard-Medium.otf in Resources */,
-				0951317E2B32CDA300F6BC4C /* APIKEY.plist in Resources */,
+				7B649C252B38767F00586040 /* APIKEY.plist in Resources */,
 				09AB7D182B26A73C0073EAD5 /* Pretendard-Thin.otf in Resources */,
 				09AB7D122B26A73C0073EAD5 /* Pretendard-SemiBold.otf in Resources */,
 				09AB7D132B26A73C0073EAD5 /* Pretendard-Light.otf in Resources */,
@@ -512,6 +513,7 @@
 				09D774FD2B283C7500D45EE6 /* LocationPickerMapView.swift in Sources */,
 				2CAFD22D2B317C4200D1B855 /* RecordBookTitleView.swift in Sources */,
 				7B1B0B682B26CFD200CD19AD /* MainMapView.swift in Sources */,
+				7B649C272B38789100586040 /* MainViewModel.swift in Sources */,
 				09731F882B26D0050045F6B4 /* BookInfoDialog.swift in Sources */,
 				B1C938902B2984B3006EFB70 /* SelectedBookListView.swift in Sources */,
 				09AB7D052B26A5500073EAD5 /* Font +.swift in Sources */,

--- a/Moment/Moment/Common/SearchBar.swift
+++ b/Moment/Moment/Common/SearchBar.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct SearchBar: View {
 	@Binding var searchText: String
 	@Binding var isTapButton: Bool
+	@Binding var isSearch: Bool
 	@FocusState var isSearchFocused: Bool
 	
 	var body: some View {
@@ -23,14 +24,15 @@ struct SearchBar: View {
 			TextField("책 제목", text: $searchText)
 				.textInputAutocapitalization(.never)
 				.focused($isSearchFocused)
-                .onSubmit {
-                    isTapButton = true
-                }
+				.onSubmit {
+					isTapButton = true
+				}
 			
 			if !searchText.isEmpty {
 				Button(action: {
 					searchText = ""
-                    isSearchFocused = true
+					isSearchFocused = true
+					isSearch = false
 				}, label: {
 					Image(systemName: "xmark")
 						.foregroundStyle(.mainBrown)
@@ -40,6 +42,7 @@ struct SearchBar: View {
 			
 			Button(action: {
 				isTapButton = true
+				isSearch = true
 				isSearchFocused = false
 				print("검색 버튼이 클릭되었습니다.")
 			}) {
@@ -62,6 +65,6 @@ struct SearchBar: View {
 
 
 
-#Preview {
-	SearchBar(searchText: .constant("안뇽"), isTapButton: .constant(false))
-}
+//#Preview {
+//	SearchBar(searchText: .constant("안뇽"), isTapButton: .constant(false))
+//}

--- a/Moment/Moment/Views/AddRecord/AddRecordView.swift
+++ b/Moment/Moment/Views/AddRecord/AddRecordView.swift
@@ -5,162 +5,162 @@ import MapKit
 struct AddRecordView: View {
 	@Environment(\.dismiss) private var dismiss
 	
-    @State private var showPickerMap: Bool = false
-    // 사용자 위치 정보
-    @State private var latitude: Double = 0
-    @State private var longitude: Double = 0
-    @State private var localName: String = "" // 민재가 쓸 데이터
-    @State private var place: String = "" // real 주소
-    // TextField 입력 정보
-    @State private var myLocation: String = ""
-    @State private var paragraph: String = ""
-    @State private var page: Int?
-    @State private var commentary: String = ""
-    // Photos
-    @State private var photoData: [UIImage?] = [
-        nil, nil, nil
-    ]
+	@State private var showPickerMap: Bool = false
+	// 사용자 위치 정보
+	@State private var latitude: Double = 0
+	@State private var longitude: Double = 0
+	@State private var localName: String = "" // 민재가 쓸 데이터
+	@State private var place: String = "" // real 주소
+	// TextField 입력 정보
+	@State private var myLocation: String = ""
+	@State private var paragraph: String = ""
+	@State private var page: Int?
+	@State private var commentary: String = ""
+	// Photos
+	@State private var photoData: [UIImage?] = [
+		nil, nil, nil
+	]
 
 	//
 	@State private var year: Int = 0
 	@State private var monthAndDay: String = ""
 	@State private var time: String = ""
 
-    @State var showMainView: Bool = false
-    @Binding var isRecord: Bool
-    
-    // 책 정보
-    let bookInfo: SelectedBook
-    @EnvironmentObject var router: Router
-    private var dataIsEmpty: Bool {
-        if [myLocation, paragraph, commentary].contains("") || page == nil || photoData[0] == nil {
-            return true
-        } else {
-            return false
-        }
-    }
+	@State var showMainView: Bool = false
+	@Binding var isRecord: Bool
+	
+	// 책 정보
+	let bookInfo: SelectedBook
+	@EnvironmentObject var router: Router
+	private var dataIsEmpty: Bool {
+		if [myLocation, paragraph, commentary].contains("") || page == nil || photoData[0] == nil {
+			return true
+		} else {
+			return false
+		}
+	}
 	
 	@Environment(\.modelContext) private var modelContext
 	@Query private var bookList: [MomentBook]
-    
-    // Alert
-    @State private var showingAlert: Bool = false
-    var body: some View {
-        ScrollView() {
-            VStack {
-                // MARK: - 책 정보
-                Text(bookInfo.title)
-                    .font(.bold20)
-                    .padding(.horizontal, 20)
-                
-                fetchImage(url: bookInfo.theCoverOfBook)
-                
-                Text(bookInfo.author)
-                    .font(.regular16)
-                    .padding(.horizontal, 20)
-                
-                // MARK: - 텍스트 필드 입력
-                VStack(alignment: .leading) {
-                    
-                    // MARK: 위치 정보
-                    Text("현재 위치")
-                        .font(.regular16)
-                    
-                    ZStack {
-                        RoundedRectangle(cornerRadius: 10)
-                            .stroke(Color.lightBrown)
-                            .foregroundStyle(.clear)
-                        
-                        HStack {
-                            Text(place)
-                                .font(.regular14)
-                            Spacer()
-                            Button {
-                                showPickerMap.toggle()
-                            } label: {
-                                Image(systemName: "map")
-                                    .foregroundStyle(.lightBrown)
-                            }
-                            .sheet(isPresented: $showPickerMap) {
-                                LocationPickerMapView(showPickerMap: $showPickerMap,
-                                                      latitude: $latitude,
-                                                      longitude: $longitude,
-                                                      localName: $localName,
-                                                      place: $place)
-                            }
-                        }
-                        .padding(10)
-                    }
-                    
-                    TextField("위치를 기억할 이름을 지어주세요.", text: $myLocation)
-                        .textFieldStyle(BorderedTextFieldStyle())
-                        .padding(.bottom, 20)
-                        .textInputAutocapitalization(.never)
-                    
-                    // MARK: 기억
-                    Text("기억할 내용")
-                        .font(.regular16)
-                    
-                    TextField("책에서 기억하고자 하는 문장을 적어주세요.", text: $paragraph)
-                        .textFieldStyle(BorderedTextFieldStyle())
-                        .textInputAutocapitalization(.never)
-                    
-                    TextField("해당 문장이 있는 페이지를 적어주세요.", value: $page, format: .number)
-                        .textFieldStyle(BorderedTextFieldStyle())
-                        .keyboardType(.asciiCapableNumberPad)
-                    
-                    TextEditor(text: $commentary)
-                        .font(.regular14)
-                        .padding(5)
-                        .frame(height: 200)
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 10)
-                                .stroke(Color.lightBrown)
-                        )
-                        .textInputAutocapitalization(.never)
-                        .keyboardType(.default)
-                
-                    ImageSelectHorizontalScrollView(photoDummyData: $photoData)
-                        .padding(.vertical)
-                    
-                    
-                    // MARK: 저장 버튼
-                    Button {
-                        if !dataIsEmpty {
-                            showingAlert.toggle()
-                        }
-                    } label: {
-                        Text(dataIsEmpty ? "아직 다 작성되지 않았어요" : "기억 저장하기")
-                            .font(.medium16)
-                    }
-                    .buttonStyle(.customProminent(color: dataIsEmpty ? .gray3 : .lightBrown))
-                    .alert("기억을 남길까요?", isPresented: $showingAlert) {
-                        Button("돌아가기") {}
-                        Button("저장하기") {
-                            isRecord = true
+	
+	// Alert
+	@State private var showingAlert: Bool = false
+	var body: some View {
+		ScrollView() {
+			VStack {
+				// MARK: - 책 정보
+				Text(bookInfo.title)
+					.font(.bold20)
+					.padding(.horizontal, 20)
+				
+				fetchImage(url: bookInfo.theCoverOfBook)
+				
+				Text(bookInfo.author)
+					.font(.regular16)
+					.padding(.horizontal, 20)
+				
+				// MARK: - 텍스트 필드 입력
+				VStack(alignment: .leading) {
+					
+					// MARK: 위치 정보
+					Text("현재 위치")
+						.font(.regular16)
+					
+					ZStack {
+						RoundedRectangle(cornerRadius: 10)
+							.stroke(Color.lightBrown)
+							.foregroundStyle(.clear)
+						
+						HStack {
+							Text(place)
+								.font(.regular14)
+							Spacer()
+							Button {
+								showPickerMap.toggle()
+							} label: {
+								Image(systemName: "map")
+									.foregroundStyle(.lightBrown)
+							}
+							.sheet(isPresented: $showPickerMap) {
+								LocationPickerMapView(showPickerMap: $showPickerMap,
+													  latitude: $latitude,
+													  longitude: $longitude,
+													  localName: $localName,
+													  place: $place)
+							}
+						}
+						.padding(10)
+					}
+					
+					TextField("위치를 기억할 이름을 지어주세요.", text: $myLocation)
+						.textFieldStyle(BorderedTextFieldStyle())
+						.padding(.bottom, 20)
+						.textInputAutocapitalization(.never)
+					
+					// MARK: 기억
+					Text("기억할 내용")
+						.font(.regular16)
+					
+					TextField("책에서 기억하고자 하는 문장을 적어주세요.", text: $paragraph)
+						.textFieldStyle(BorderedTextFieldStyle())
+						.textInputAutocapitalization(.never)
+					
+					TextField("해당 문장이 있는 페이지를 적어주세요.", value: $page, format: .number)
+						.textFieldStyle(BorderedTextFieldStyle())
+						.keyboardType(.asciiCapableNumberPad)
+					
+					TextEditor(text: $commentary)
+						.font(.regular14)
+						.padding(5)
+						.frame(height: 200)
+						.overlay(
+							RoundedRectangle(cornerRadius: 10)
+								.stroke(Color.lightBrown)
+						)
+						.textInputAutocapitalization(.never)
+						.keyboardType(.default)
+				
+					ImageSelectHorizontalScrollView(photoDummyData: $photoData)
+						.padding(.vertical)
+					
+					
+					// MARK: 저장 버튼
+					Button {
+						if !dataIsEmpty {
+							showingAlert.toggle()
+						}
+					} label: {
+						Text(dataIsEmpty ? "아직 다 작성되지 않았어요" : "기억 저장하기")
+							.font(.medium16)
+					}
+					.buttonStyle(.customProminent(color: dataIsEmpty ? .gray3 : .lightBrown))
+					.alert("기억을 남길까요?", isPresented: $showingAlert) {
+						Button("돌아가기") {}
+						Button("저장하기") {
+							isRecord = true
 							Task {
 								await swiftDataInsert()
 							}
-                            showMainView = true
-                            router.clear()
-                        }
-                    } message: {
-                        Text("저장된 기억은 수정할 수 없어요...🥲")
-                    }
-                }
-                .padding(20)
-            }
-        }
-        .scrollDismissesKeyboard(.immediately)
-        .task {
-            await getLocationManager()
+//                            showMainView = true
+							router.clear()
+						}
+					} message: {
+						Text("저장된 기억은 수정할 수 없어요...🥲")
+					}
+				}
+				.padding(20)
+			}
 		}
-        .navigationDestination(isPresented: $showMainView) {
-            MainView()
-        }
-        .onTapGesture {
-            hideKeyboard()
-        }
+		.scrollDismissesKeyboard(.immediately)
+		.task {
+			await getLocationManager()
+		}
+//        .navigationDestination(isPresented: $showMainView) {
+//            MainView()
+//        }
+		.onTapGesture {
+			hideKeyboard()
+		}
 		.navigationBarBackButtonHidden()
 		.toolbar {
 			ToolbarItem(placement: .topBarLeading) {
@@ -172,52 +172,52 @@ struct AddRecordView: View {
 				}
 			}
 		}
-    }
+	}
 
-    func getLocationManager() async {
-        let manager = CLLocationManager()
-        manager.requestWhenInUseAuthorization()
-        await withCheckedContinuation { continuation in
-            Task {
-                // 위치 정보 동의가 이루어질 때까지 대기
-                while manager.authorizationStatus == .notDetermined {
-                    try await Task.sleep(nanoseconds: 100_000_000)  // 0.1초
-                }
-                if manager.authorizationStatus == .authorizedWhenInUse || manager.authorizationStatus == .authorizedAlways {
-                    manager.desiredAccuracy = kCLLocationAccuracyBest
-                    await fetchLocation(manager: manager)
-                }
-                continuation.resume()
-            }
-        }
-    }
-    
-    func fetchLocation(manager: CLLocationManager) async {
-        guard let location = manager.location else { return }
-        self.latitude = location.coordinate.latitude
-        self.longitude = location.coordinate.longitude
-        let cllocation = CLLocation(latitude: self.latitude, longitude: self.longitude)
-        let geocoder = CLGeocoder()
-        let locale = Locale(identifier: "ko-KR")
-        do {
-            let placemarks = try await geocoder.reverseGeocodeLocation(cllocation, preferredLocale: locale)
-            if let address = placemarks.last {
-                self.place = "\(address.country ?? "") \(address.locality ?? "") \(address.name ?? "")"
-                self.localName = address.administrativeArea ?? ""
-            }
-        } catch let error {
-            print("Geocoding error: \(error.localizedDescription)")
-        }
-    }
-    
-    func fetchImage(url: String) -> some View {
-        AsyncImage(url: URL(string: url)) { image in
-            image.resizable()
-        } placeholder: {
-            ProgressView()
-        }
-        .frame(width: 70, height: 87)
-    }
+	func getLocationManager() async {
+		let manager = CLLocationManager()
+		manager.requestWhenInUseAuthorization()
+		await withCheckedContinuation { continuation in
+			Task {
+				// 위치 정보 동의가 이루어질 때까지 대기
+				while manager.authorizationStatus == .notDetermined {
+					try await Task.sleep(nanoseconds: 100_000_000)  // 0.1초
+				}
+				if manager.authorizationStatus == .authorizedWhenInUse || manager.authorizationStatus == .authorizedAlways {
+					manager.desiredAccuracy = kCLLocationAccuracyBest
+					await fetchLocation(manager: manager)
+				}
+				continuation.resume()
+			}
+		}
+	}
+	
+	func fetchLocation(manager: CLLocationManager) async {
+		guard let location = manager.location else { return }
+		self.latitude = location.coordinate.latitude
+		self.longitude = location.coordinate.longitude
+		let cllocation = CLLocation(latitude: self.latitude, longitude: self.longitude)
+		let geocoder = CLGeocoder()
+		let locale = Locale(identifier: "ko-KR")
+		do {
+			let placemarks = try await geocoder.reverseGeocodeLocation(cllocation, preferredLocale: locale)
+			if let address = placemarks.last {
+				self.place = "\(address.country ?? "") \(address.locality ?? "") \(address.name ?? "")"
+				self.localName = address.administrativeArea ?? ""
+			}
+		} catch let error {
+			print("Geocoding error: \(error.localizedDescription)")
+		}
+	}
+	
+	func fetchImage(url: String) -> some View {
+		AsyncImage(url: URL(string: url)) { image in
+			image.resizable()
+		} placeholder: {
+			ProgressView()
+		}
+		.frame(width: 70, height: 87)
+	}
 	
 	private func imageToData() async -> [Data] {
 		var imageDatas: [Data] = []

--- a/Moment/Moment/Views/Main/MainMap/MainMapView.swift
+++ b/Moment/Moment/Views/Main/MainMap/MainMapView.swift
@@ -17,23 +17,23 @@ struct MainMapView: View {
 	@Binding var recordList: [MomentRecord]
 	@State var dict: [LocalName: [MomentRecord]] = [:]
 	let localNames = LocalName.allCases
-    @State private var region = MKCoordinateRegion(center: CLLocationCoordinate2D(latitude: 36.358391, longitude: 127.859669),
-                                                   span: MKCoordinateSpan(latitudeDelta: 6, longitudeDelta: 6))
+	@State private var region = MKCoordinateRegion(center: CLLocationCoordinate2D(latitude: 36.358391, longitude: 127.859669),
+												   span: MKCoordinateSpan(latitudeDelta: 6, longitudeDelta: 6))
 	
 	var body: some View {
-        Map(initialPosition: MapCameraPosition.region(region),
-            bounds: .init(MapCameraBounds(maximumDistance: 1600000)), interactionModes: [.pan, .pitch, .zoom]) {
+		Map(initialPosition: MapCameraPosition.region(region),
+			bounds: .init(MapCameraBounds(maximumDistance: 1600000)), interactionModes: [.pan, .pitch, .zoom]) {
 			// 딕셔너리가 비어있지 않을 때
 			if !dict.isEmpty {
 				// 딕셔너리의 키값으로 배열을 매핑 후 순회
 				ForEach(dict.map { $0.key }, id: \.self) { local in
 					if let data = dict[local]?.first, let count = dict[local]?.count, let bookRecordList = dict[local] {
-                        let bookISBNList = Set(bookRecordList.map { $0.bookISBN }).map { $0 }
+						let bookISBNList = Set(bookRecordList.map { $0.bookISBN }).map { $0 }
 						Annotation("", coordinate: local.coodinate, anchor: .bottom) {
 							NavigationLink {
-                                MapToRecordListView(bookISBNList: bookISBNList,
-                                                    recordList: bookRecordList,
-                                                    localName: local.rawValue)
+								MapToRecordListView(bookISBNList: bookISBNList,
+													recordList: bookRecordList,
+													localName: local.rawValue)
 							} label: {
 								ZStack {
 									RoundRectBalloon()
@@ -60,31 +60,29 @@ struct MainMapView: View {
 				}
 			}
 		}
-		.onAppear {
-			fetchLocalData()
+		.task {
+			await fetchLocalData()
 		}
 		.onChange(of: recordList) {
 			Task {
-				print(recordList)
-				fetchLocalData()
-				print(dict)
+				print("MainMapView에서 recordList 변경사항 있음")
+				await fetchLocalData()
 			}
 		}
 	}
 	
-	func fetchLocalData() {
-		DispatchQueue.main.async {
-			dict = Dictionary(grouping: recordList) { record in
-				if let localName = localNames.first(where: { $0.rawValue == record.localName }) {
-					return localName
-				} else {
-					return LocalName.defaultCase
-				}
+	@MainActor
+	func fetchLocalData() async {
+		dict = Dictionary(grouping: recordList) { record in
+			if let localName = localNames.first(where: { $0.rawValue == record.localName }) {
+				return localName
+			} else {
+				return LocalName.defaultCase
 			}
-			.compactMapValues { records in
-				records.reduce(into: []) { result, record in
-					result.append(record)
-				}
+		}
+		.compactMapValues { records in
+			records.reduce(into: []) { result, record in
+				result.append(record)
 			}
 		}
 	}

--- a/Moment/Moment/Views/Main/MainShelf/MainShelfView.swift
+++ b/Moment/Moment/Views/Main/MainShelf/MainShelfView.swift
@@ -10,41 +10,46 @@ import SwiftData
 
 struct MainShelfView: View {
 	@Binding var bookList: [MomentBook]
-    @Binding var recordSearchText: String
+	@Binding var recordSearchText: String
 	
 	@State var showShlefListView: Bool = false
 	
-    @FocusState var isSearchFocused: Bool
-    
-    let geo: GeometryProxy
-
-    var body: some View {
-        ZStack(alignment: .bottomTrailing) {
-            if bookList.isEmpty {
-                NoContentView()
-                    .padding(EdgeInsets(top: 0, leading: 20, bottom: 60, trailing: 20))
-            } else {
-                ScrollView(.vertical, showsIndicators: false) {
-                    ContentShelfView(bookList: $bookList, geo: geo)
-                        .padding(.bottom, 40)
-                }
-            }
-            
-			Button(action: {
-				showShlefListView = true
-			}, label: {
+	@FocusState var isSearchFocused: Bool
+	
+	let geo: GeometryProxy
+	
+	var body: some View {
+		ZStack(alignment: .bottomTrailing) {
+			if bookList.isEmpty {
+				NoContentView()
+					.padding(EdgeInsets(top: 0, leading: 20, bottom: 60, trailing: 20))
+			} else {
+				ScrollView(.vertical, showsIndicators: false) {
+					ContentShelfView(bookList: $bookList, geo: geo)
+						.padding(.bottom, 40)
+				}
+			}
+			
+//			Button(action: {
+//				showShlefListView = true
+//			}, label: {
+//				Image(systemName: "plus")
+//					.font(.system(size: 30))
+//					.fontWeight(.medium)
+//			})
+			NavigationLink(value: Route.ShelfRecordLisview) {
 				Image(systemName: "plus")
 					.font(.system(size: 30))
 					.fontWeight(.medium)
-			})
+			}
 			.buttonStyle(.circled(color: .lightBrown, size: 30))
 			.padding([.bottom, .trailing], 30)
-            .navigationDestination(isPresented: $showShlefListView) {
+			.navigationDestination(for: Route.self) { _ in
 				SelectedBooktoAPIView()
-            }
-        }
-        .ignoresSafeArea()
-    }
+			}
+		}
+		.ignoresSafeArea()
+	}
 }
 
 //#Preview {

--- a/Moment/Moment/Views/Main/MainView.swift
+++ b/Moment/Moment/Views/Main/MainView.swift
@@ -16,84 +16,102 @@ struct MainView: View {
 	@State var recordSearchText = "" // 기억 검색 텍스트 저장 프로퍼티
 	@State var isTapSearchButton = false // 검색 버튼탭 여부 저장 프로퍼티
 	
-	@State var mainBookList: [MomentBook] = []
-	@State var mainRecordList: [MomentRecord] = []
+	@State var mainBookList: [MomentBook] = [] // 저장되어있는 모든 책 리스트 저장 프로퍼티
+	@State var mainRecordList: [MomentRecord] = [] // 저장되어있는 모든 책 기록 리스트 저장 프로퍼티
+	
+	@State var searchBookList: [MomentBook] = [] // 검색된 책 리스트 저장 프로퍼티
+	@State var searchRecordList: [MomentRecord] = [] // 검색된 책들의 기록 리스트 저장 프로퍼티
 	
 	@FocusState var isSearchFocused: Bool
-    @StateObject var router = Router()
+	@State var isSearch: Bool = false // 검색중인 상태를 나타내는 프로퍼티
+	
+	@StateObject var router = Router()
 
 	var body: some View {
-        GeometryReader { geo in
-            NavigationStack(path: $router.path) {
-                VStack(spacing: 0) {
-                    if selectedOption == 0 {
-                        VStack(spacing: 20) {
-                            SearchBar(searchText: $recordSearchText,
-                                      isTapButton: $isTapSearchButton,
-                                      isSearchFocused: _isSearchFocused)
-                            .padding(.horizontal, 20)
-                            SegmentBar(preselectedIndex: $selectedOption, geo: geo)
-                            
-                            MainShelfView(bookList: $mainBookList, recordSearchText: $recordSearchText, isSearchFocused: _isSearchFocused, geo: geo)
-                        }
-                    } else if selectedOption == 1 {
-                        ZStack(alignment: .top) {
-                            MainMapView(recordList: $mainRecordList)
-                            VStack(spacing: 20) {
-                                SearchBar(searchText: $recordSearchText,
-                                          isTapButton: $isTapSearchButton,
-                                          isSearchFocused: _isSearchFocused)
-                                .padding(.horizontal, 20)
-                                SegmentBar(preselectedIndex: $selectedOption, geo: geo)
-                            }
-                        }
-                    }
-                }
-                //MARK: [추후 업데이트] 문제3 수정
+		GeometryReader { geo in
+			NavigationStack(path: $router.path) {
+				VStack(spacing: 0) {
+					if selectedOption == 0 {
+						VStack(spacing: 20) {
+							SearchBar(searchText: $recordSearchText,
+									  isTapButton: $isTapSearchButton,
+									  isSearch: $isSearch,
+									  isSearchFocused: _isSearchFocused)
+							.padding(.horizontal, 20)
+							SegmentBar(preselectedIndex: $selectedOption, geo: geo)
+							
+							MainShelfView(bookList: isSearch ? $searchBookList : $mainBookList,
+										  recordSearchText: $recordSearchText,
+										  isSearchFocused: _isSearchFocused,
+										  geo: geo)
+						}
+					} else if selectedOption == 1 {
+						ZStack(alignment: .top) {
+							MainMapView(recordList: isSearch ? $searchRecordList : $mainRecordList)
+							VStack(spacing: 20) {
+								SearchBar(searchText: $recordSearchText,
+										  isTapButton: $isTapSearchButton,
+										  isSearch: $isSearch,
+										  isSearchFocused: _isSearchFocused)
+								.padding(.horizontal, 20)
+								SegmentBar(preselectedIndex: $selectedOption, geo: geo)
+							}
+						}
+					}
+				}
+				//MARK: [추후 업데이트] 문제3 수정
 //                .onDisappear(perform: {
 //                    recordSearchText = ""
 //                })
-                .onChange(of: isTapSearchButton) {
-                    if isTapSearchButton && !recordSearchText.isEmpty {
-                        mainRecordList = recordSearch(bookSearch: bookSearch)
-                    }
-                    isTapSearchButton = false
-                }
-                .onChange(of: recordSearchText) {
-                    if recordSearchText.isEmpty {
-                        mainRecordList = recordList
-                        mainBookList = bookList
-                    }
-                }
-                .onChange(of: recordList) {
-                    mainBookList = bookList
-                    mainRecordList = recordList
-                }
-                .navigationBarBackButtonHidden(true)
-            }
-            .environmentObject(router)
-            .tint(.darkBrown)
-            .onAppear {
-                mainBookList = bookList
-                mainRecordList = recordList
-            }
-            .onTapGesture {
-                hideKeyboard()
-            }
-        }
+				.onChange(of: isTapSearchButton) {
+					Task {
+						if isTapSearchButton && !recordSearchText.isEmpty {
+							searchRecordList = await recordSearch(bookSearch: bookSearch)
+						}
+						isTapSearchButton = false
+					}
+				}
+				.onChange(of: recordList) {
+					Task {
+						mainBookList = bookList
+						mainRecordList = recordList
+						
+						// Query로 저장되어있는 기록리스트 변경 시 검색된 데이터가 있다면 데이터 업데이트
+						if isSearch {
+							searchRecordList = await recordSearch(bookSearch: bookSearch)
+						}
+					}
+				}
+				.navigationBarBackButtonHidden(true)
+			}
+			.environmentObject(router)
+			.tint(.darkBrown)
+//            .onAppear {
+//                mainBookList = bookList
+//                mainRecordList = recordList
+//            }
+			.task {
+				mainBookList = bookList
+				mainRecordList = recordList
+			}
+			.onTapGesture {
+				hideKeyboard()
+			}
+		}
 	}
 	
-	func recordSearch(bookSearch: () -> [MomentBook]) -> [MomentRecord] {
-		self.mainBookList = bookSearch()
-		let result = self.mainBookList.reduce(into: [MomentRecord]()) { recordList, book in
+	@MainActor
+	func recordSearch(bookSearch: () async -> [MomentBook]) async -> [MomentRecord] {
+		self.searchBookList = await bookSearch()
+		let result = self.searchBookList.reduce(into: [MomentRecord]()) { recordList, book in
 			recordList += self.recordList.filter { $0.bookISBN == book.bookISBN }
 		}
 		return result
 	}
 	
-	func bookSearch() -> [MomentBook] {
-		let result = bookList
-			.filter { $0.title.localizedStandardContains(recordSearchText) }
+	@MainActor
+	func bookSearch() async -> [MomentBook] {
+		let result = bookList.filter { $0.title.localizedStandardContains(recordSearchText) }
 		return result
 	}
 }
@@ -101,4 +119,3 @@ struct MainView: View {
 //#Preview {
 //	MainView()
 //}
-

--- a/Moment/Moment/Views/Main/MainViewModel.swift
+++ b/Moment/Moment/Views/Main/MainViewModel.swift
@@ -1,0 +1,40 @@
+//
+//  MainViewModel.swift
+//  Moment
+//
+//  Created by Minjae Kim on 12/24/23.
+//
+
+import SwiftUI
+
+class MainViewModel: ObservableObject {
+	@Published var selectedOption = 0 // 세그먼트 인덱스 저장 프로퍼티
+	@Published var recordSearchText = "" // 기억 검색 텍스트 저장 프로퍼티
+	@Published var isTapSearchButton = false // 검색 버튼탭 여부 저장 프로퍼티
+	
+	@Published var mainBookList: [MomentBook] = [] // 저장되어있는 모든 책 리스트 저장 프로퍼티
+	@Published var mainRecordList: [MomentRecord] = [] // 저장되어있는 모든 책 기록 리스트 저장 프로퍼티
+	
+	@Published var searchBookList: [MomentBook] = [] // 검색된 책 리스트 저장 프로퍼티
+	@Published var searchRecordList: [MomentRecord] = [] // 검색된 책들의 기록 리스트 저장 프로퍼티
+	
+	@Published var isSearch: Bool = false // 검색중인 상태를 나타내는 프로퍼티
+	@FocusState var isSearchFocused: Bool
+	
+	@Published var path = NavigationPath()
+	
+	@MainActor
+	func recordSearch(bookSearch: ([MomentBook]) async -> [MomentBook], bookList: [MomentBook], recordList: [MomentRecord]) async -> [MomentRecord] {
+		searchBookList = await bookSearch(bookList)
+		let result = searchBookList.reduce(into: [MomentRecord]()) { recordList, book in
+			recordList += recordList.filter { $0.bookISBN == book.bookISBN }
+		}
+		return result
+	}
+	
+	@MainActor
+	func bookSearch(bookList: [MomentBook]) async -> [MomentBook] {
+		let result = bookList.filter { $0.title.localizedStandardContains(recordSearchText) }
+		return result
+	}
+}

--- a/Moment/Moment/Views/SelectBook/SelectedBookListView.swift
+++ b/Moment/Moment/Views/SelectBook/SelectedBookListView.swift
@@ -22,7 +22,7 @@ struct SelectedBooktoAPIView: View {
 	@State private var searchBookText = ""
 	@State var showBool = false
 	@State var noResults = false
-    @State var isRecord = false
+	@State var isRecord = false
 	
 	var body: some View {
 		VStack(spacing: -30) {
@@ -30,16 +30,19 @@ struct SelectedBooktoAPIView: View {
 				.padding(20)
 			VStack(alignment: .leading, spacing: -30) {
 				if searchBookText == "" {
-                    Text(bookList.count == 0 ? "" : "기억에 남겨진 책")
+					Text(bookList.count == 0 ? "" : "기억에 남겨진 책")
 						.font(Font.semibold18)
 						.padding(30)
 					VStack {
 						ScrollView {
 							VStack(alignment: .leading, spacing: -30) {
 								ForEach(bookList, id: \.self) { book in
-									NavigationLink{
-										AddRecordView(isRecord: $isRecord, bookInfo: book)
-									} label: {
+//									NavigationLink{
+//										AddRecordView(isRecord: $isRecord, bookInfo: book)
+//									} label: {
+//										SelectedBookCell(bookInfo: book)
+//									}
+									NavigationLink(value: book) {
 										SelectedBookCell(bookInfo: book)
 									}
 									CustomListDivider()
@@ -67,11 +70,14 @@ struct SelectedBooktoAPIView: View {
 						ScrollView {
 							VStack(alignment: .leading, spacing: -30) {
 								ForEach(searchResults, id: \.self) { book in
-									NavigationLink {
-                                        AddRecordView(isRecord: $isRecord, bookInfo: book)
-									} label: {
+									NavigationLink(value: book) {
 										SelectedBookCell(bookInfo: book)
 									}
+//									NavigationLink {
+//                                        AddRecordView(isRecord: $isRecord, bookInfo: book)
+//									} label: {
+//										SelectedBookCell(bookInfo: book)
+//									}
 									CustomListDivider()
 								}
 							}
@@ -80,12 +86,18 @@ struct SelectedBooktoAPIView: View {
 				}
 			}
 		}
-        .onChange(of: isRecord) {
-            if isRecord {
-                searchBookText = ""
-                isRecord = false
-            }
-        }
+		.navigationDestination(for: MomentBook.self) { value in
+			AddRecordView(isRecord: $isRecord, bookInfo: value)
+		}
+		.navigationDestination(for: Book.self) { value in
+			AddRecordView(isRecord: $isRecord, bookInfo: value)
+		}
+		.onChange(of: isRecord) {
+			if isRecord {
+				searchBookText = ""
+				isRecord = false
+			}
+		}
 		.onChange(of: searchBookText) {
 			if searchBookText.isEmpty {
 				searchResults = []


### PR DESCRIPTION
1. 네비게이션 스택 에러 - 기록저장 후 메인뷰를 한 번 더 푸시해주어 네비게이션 스택에 메인뷰가 두 개 쌓여버리는 문제가 발생했음.
2. 메인 쿼리 데이터와 검색 상태일 때의 필터된 쿼리 데이터를 다른 변수를 통해 관리
3. 검색중인 상태와 아닌 상태에 따라서 메인뷰에 뿌려주는 책 및 책에 대한 기록 데이터 분리해서 보여줌
4. 기록 삭제 후 맵에서 데이터가 업데이트 되지 않는 현상 - onChange 메서드를 활용하여 필터링된 쿼리 데이터 업데이트 해줌