### PR TITLE
네비게이션 스택 수정-feature-13-13.15

### DIFF
--- a/Moment/Moment.xcodeproj/project.pbxproj
+++ b/Moment/Moment.xcodeproj/project.pbxproj
@@ -667,7 +667,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Moment/Preview Content\"";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = T62JF6T7Q4;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Moment/Info.plist;
@@ -687,7 +687,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.Boooook.Moment;
+				PRODUCT_BUNDLE_IDENTIFIER = kr.co.kmj.Moment;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -703,7 +703,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Moment/Preview Content\"";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = T62JF6T7Q4;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Moment/Info.plist;
@@ -723,7 +723,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.Boooook.Moment;
+				PRODUCT_BUNDLE_IDENTIFIER = kr.co.kmj.Moment;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;


### PR DESCRIPTION
1. navigationStack path 관련 수정사항
    - NavigationLink 와 .navigationDestination 을 통해 NavigationStack Path에 쌓아줌
    - destination을 통해 View를 넘어갈 경우 데이터 넘겨줄 때 NavigationLink(value: ) 이 value 에 값을 넘겨주면 됨.
   
2. View dismiss 관련 수정사항
    - Custom NavigationBarBackButton 사용으로 인하여
    - View dismiss할 시 @Environment(\.dismiss) var dismiss를 활용하였었으나
    - Router 객체에서 관리해주는 NavigationPath의 path 스택에서
    - path.removeLast를 통해 View 뒤로가기 구현